### PR TITLE
Design Proposal of EOS VMs improvements for Parallel Read-only Transaction Execution

### DIFF
--- a/transactions/read-only/memory.md
+++ b/transactions/read-only/memory.md
@@ -419,12 +419,10 @@ its code was used is before LIB and its linked execution context is not running.
 takes a module as an input and skips parsing.
 
 To resolve the issue of potential multiple threads modifying the same global stored in the module,
-globals storage is moved out to the end of linear memory. Protection will be put into place to prevent this section is accessed
-by contract code.
-
+globals are moved out of module and placed in execution context.
 
 Functions `set_global` and `get_global` in `execution_context.hpp`, `emit_get_global` and `emit_set_global` in `x86_64.hpp` will
-be modified to access globals in linear memory.
+be modified to access globals in execution context.
 
 ```mermaid
 flowchart TD

--- a/transactions/read-only/memory.md
+++ b/transactions/read-only/memory.md
@@ -1,37 +1,30 @@
 # Parallel Read-only Transaction Execution Improvements
-Several improvement ideas related to WASM execution of parallel read-only trxs were identified: parsing contracts only once (https://github.com/AntelopeIO/leap/issues/800), reducing EOS-VM-OC memory slice count (https://github.com/AntelopeIO/leap/issues/645), and calculating virtual memory available to user space correctly (https://github.com/AntelopeIO/leap/issues/801).
 
-This document describes the background and solutions.
+During parallel read-only transaction implementation (https://github.com/eosnetworkfoundation/product/blob/main/transactions/read-only/parallel.md, https://github.com/AntelopeIO/leap/pull/776), several improvement ideas related to WASM execution were identified: parsing contracts only once (https://github.com/AntelopeIO/leap/issues/800), reducing EOS-VM-OC memory slice count (https://github.com/AntelopeIO/leap/issues/645), calculating virtual memory available to user space accurately (https://github.com/AntelopeIO/leap/issues/801), and falling back to parallel EOS-VM-Interpreter or EOS-VM-JIT execution if OC compiled
+code is not available (https://github.com/AntelopeIO/leap/issues/1119).
 
-## WASM Execution
-A transaction execution goes through two major phases:
-1. The smart contract of the transaction's actions are translated by CDT from C++ into WASM code.
-2. The WASM is executed by an EOS VM.
+This document describes the background and proposes design.
 
-`nodeos` supports three types of VMs for WASM execution: EOS-VM (interpreter), EOS-VM-JIT, and EOS-VM-OC.
+## Background
 
-At `nodeos` startup, resources required by WASM execution are created:
-- a WAMS interface `wasmif`
-- a `EOS-VM` or `EOS-VM-JIT` run time interface `eos_vm_runtime` (based on configuration option `--wasm-runtime`),
-- and a `eosvmoc_tier` (when `--eos-vm-oc-enable` is configured). `eosvmoc_tier` contains `eosvmoc::executor`
-and `eosvmoc::memory` used for execution. 
+### WASM Execution
+In Leap, smart contracts are written in C++. To execute a transaction, its contract code is first translated into WASM (WebAssembly)
+by CDT; the WASM code is then executed on a VM.
 
-```mermaid
-flowchart TD
-    wasmif[create wasmif] --> runtime
-    runtime{EOS-VM or EOS-VM-JIT?} -->|JIT| jitVM
-    runtime -->|interpreter| intVM
-    jitVM[create JIT eos_vm_runtime] --> ocEnabled
-    intVM[create interpreter eos_vm_runtime] --> ocEnabled
-    ocEnabled{eos-vm-oc-enable?} -->|yes| ocTier
-    ocTier[create eosvmoc_tier]
-```
+Leap supports three types of VMs: EOS-VM-Interpreter, EOS-VM-JIT, and EOS-VM-OC.
 
-### EOS-VM and EOS-VM-JIT Execution
+#### Concepts
 
-EOS-VM and EOS-VM-JIT execute similarly. Both involves module, execution context, and backend.
+This section describes concepts necessary to understand WASM execution.
 
-A module stores information about a parsed WASM code, consisting of WASM section definitions and generated bitcode or X86 machine code.
+##### Module
+
+Module is the fundamental unit of code in WASM. It consists of data and code definitions, representing executable form of a contract.
+Given a WASM code, the EOS VM parser parses the code, generates bitcode for EOS-VM-Interpreter and X86 machine code for EOS-VM-JIT,
+and stores the result in a module, as shown below.
+
+A module object is created by WASM interface as a part of a backend before executing a transaction.
+
 ```mermaid
 classDiagram
    class module {
@@ -45,123 +38,163 @@ classDiagram
       guarded_vector<global_variable> globals; // globals definitions and storage 
       guarded_vector<export_entry>    exports; // export functions
       guarded_vector<elem_segment>    elements; // element definitions
-      guarded_vector<function_body>   code; // generated code
+      guarded_vector<function_body>   code; // generated bitcode or X86 machine code
       guarded_vector<data_segment>    data; // initial data
    }
 ```
 
-An execution context provides a runtime environment to execute a function (action). It instantiates a module by linking the module with
-linear memory and stack, and initializing memory.
+##### Execution Context
+
+An execution context links a module with linear memory, stack, WASM allocator, and host functions.
+It provides specific execution methods for EOS-VM-Interpreter and EOS-VM-JIT.
+An execution context object is created by WASM interface as a part of a backend.
+
 ```mermaid
 classDiagram
    class execution_context_base {
-      char*                           _linear_memory;
-      module&                         _mod;
-      wasm_allocator*                 _wasm_alloc;
-      detail::host_invoker_t<Host>    _rhf;
-      operand_stack                   _os;
+      char*                           linear memory;
+      module&                         parsed module;
+      wasm_allocator*                 wasm allocator;
+      detail::host_invoker_t<Host>    host functions;
+      operand_stack                   stack;
    }
    class jit_execution_context {
       execute()
-      ...()
+      "...()"
    }
-   class execution_context {
+   class interpreter_execution_context {
       execute()
-      ...()
+      "...()"
    }
    execution_context_base <|-- jit_execution_context
-   execution_context_base <|-- execution_context
+   execution_context_base <|-- interpreter_execution_context
 ```
 
-A backend encapsulates everything required for execution an action. The constructor of `backend` takes code,
-host functions, allocator and options as input, constructs a parser, parses the code, and creates the execution context as an output.
+##### Backend
+A backend represents a runtime environment to execute any action in a contract. 
+Before execution, a backend object for the contract is created by WASM interface if it is not cached, 
+otherwise the cached backend is used.
 
-Put together, given a contract WASM code and a function (action), `wasmif` executes the function in the following steps:
+```mermaid
+classDiagram
+   class backend {
+      wasm_allocator* memory_alloc; // WASM allocator
+      module          mod; // parsed module
+      DebugInfo       debug;
+      context_t       ctx; // execution context
+      initialize(host_t*, const Options&);  // initialize memory and set up host functions
+      void timed_run(Watchdog&&, F&&); // execute a function (F) with a deadline timer
+      void set_wasm_allocator(wasm_allocator*) // set WASM allocator
+      "...()"
+   }
+```
+
+##### EOS-VM-OC Tierup
+If `--eos-vm-oc-enable` is configured, EOS-VM-OC tierup is constructed by WASM interface at `nodeos` startup.
+It is the runtime environment for EOS-VM-OC execution. It consists of a code cache, an executor and a memory.
+The code cache stores OC compiled code. The executor executes the compiled code using the memory.
+```mermaid
+classDiagram
+   class eosvmoc_tierup {
+      eosvmoc::code_cache_async cc; // code cache
+      eosvmoc::executor exec;
+      eosvmoc::memory mem;
+   }
+```
+
+##### WASM Interface
+WASM interface provides an abstraction of low level execution details, acting as an interface between
+transaction level (receiver, action, applied context) and WASM code level (module, execution context/executor, memory).
+
+A WASM interface object is created at `nodeos` startup. It consists of a backend cache for EOS-VM-Interpreter and EOS-VM-JIT execution,
+and a EOS-VM-OC tierup object for EOS-VM-OC execution if enabled. To execute an action, simply call the `apply` method:
+```
+apply( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context )
+```
+
+#### Execution
+
+At high level, WASM interface executes an action in one of two cases:
+1. EOS-VM-OC enabled: if the code has been OC compiled, the execution is performed by EOS-VM-OC; if the code is not ready, the execution falls back to EOS-VM-Interpreter or EOS-VM-JIT.
+2. EOS-VM-OC not enabled: the execution is performed by EOS-VM-Interpreter or EOS-VM-JIT.
 
 ```mermaid
 flowchart TD
+    isEosvmoc{"EOS VM OC enabled?"} -->|Yes| isOcCached
+    isEosvmoc -->|No| interpreterJitExec
+    
+    isOcCached{OC compiled code available?} -->|Yes| ocExec
+    isOcCached -->|No| interpreterJitExec
+    
+    ocExec[[OC execution]]
+    interpreterJitExec[[Interpreter and JIT execution]]
+```
+
+##### EOS-VM-Interpreter and EOS-VM-JIT Execution
+In EOS-VM-Interpreter and EOS-VM-JIT execution, a backend is required per code.
+WASM interface maintains a cache of used backends.
+If a code's backend exists, it is re-initialized and reused; otherwise a new backend is created.
+
+```mermaid
+flowchart TD
+    interpreterJitExec[[Interpreter and JIT execution]] --> isBackendCached
     isBackendCached{backend for the code cached?} -->|No| backend
-    isBackendCached -->|Yes| exec
-    backend[create a backend] --> module
-    module[create a module] --> isjit
+    isBackendCached -->|Yes| initCallDepth
+    backend[create a backend] --> isjit
     isjit{JIT?} -->|JIT| jitParse
     isjit -->|interpreter| intParse
-    jitParse[parse the contract code, populate module, generate X86 machine code] --> jitCtx
-    intParse[parse the contract code, populate module, generate bitcode] --> intCtx
-    jitCtx[create a JIT execution context] --> exec
-    intCtx[create an interpreter execution context] --> exec
+    jitParse[parse the code, generate X86 machine code] --> jitCtx
+    intParse[parse the code, generate bitcode] --> intCtx
+    jitCtx[create a JIT execution context] --> cacheBackend
+    intCtx[create an interpreter execution context] --> cacheBackend
+    cacheBackend[Cache the backend] --> initCallDepth
+    initCallDepth["backend initializes execution context's max call depth and max memory pages"] --> initMem
+    initMem["backend resets execution context's linear memory"] --> execFunc
+    execFunc["backend calls execution context's execute()"]
+```
+
+##### EOS-VM-OC Execution
+In EOS-VM-OC, compiling and execution are done asynchronously. If the OC compiled code is not available, the execution falls back to EOS-VM-Interpreter or EOS-VM-JIT, while at the same time the compiling is kicked off in a new process.
+The compiled code is cached both in memory and on disk for future uses.
+
+```mermaid
+flowchart TD
+    isBlacklisted{blacklisted?} -->|Yes| interpreterJitExec
+    isBlacklisted -->|No| isOcBeingCompiled
+    isOcBeingCompiled{being compiled?} -->|Yes| interpreterJitExec
+    isOcBeingCompiled -->|No| isQueued
+    isQueued{queued?} -->|Yes| interpreterJitExec
+    isQueued -->|No| isTooMany
+    isTooMany{number of outstanding\n compile tasks greater\n than the configured?} -->|Yes| queuing
+    queuing[queue the compile request] --> interpreterJitExec
+    isTooMany -->|No| ocCompiling
+    ocCompiling["start a process to compile"] --> interpreterJitExec
+    
+    interpreterJitExec[[Interpreter and JIT execution]]
+```
+
+
+EOS-VM-OC tierup executes the compiled code using OC executor() and OC memory. 
+```mermaid
+flowchart TD
+    ocExec[[OC execution]]
+    ocExec[executor::execute] --> mem
+    mem[prepare memory] --> cb
+    cb[prepare control block] --> exec
     exec[execute the function]
 ```
 
-### EOS-VM-OC Execution
-To improve the performance, EOS-VM-OC compiles and generates optimized code.
+#### Parallel EOS-VM and EOS-VM-JIT Execution
 
-Given a contract WASM code and a function, `eosvmoc_tier` executes the function in the following steps:
-
-```mermaid
-flowchart TD
-    cached{code compiled and cached?} -->|yes| exec
-    cached -->|no| default
-    exec[executor::execute] --> mem
-    mem[prepare memory] --> cb
-    cb[prepare control block] --> setApply
-    setApply[set up apply func] --> apply
-    apply["call apply func"]
-    default[fall back to base runtime for execution]
-```
-#### Memory Slices
-
-The description of this section is from https://github.com/AntelopeIO/leap/issues/645.
-
-EOS-VM-OC uses a memory mirroring technique so that WASM linear memory can be both protected via page access permissions
-and be resized without using `mprotect()`. EOS VM OC refers to these mirrors as "slices".
-
-Prior to 2.1/3.1, Antelope's WASM memory could never exceed 33MiB. EOS-VM-OC would set up `33MiB/64KiB+1=529` slices each
-with approximately `4GiB+33MiB` of virtual memory. This meant that EOS-VM-OC required approximately `529*(4GiB+33MiB)` of virtual memory;
-about 2.1TiB.
-
-In 2.1+/3.1+ Antelope technically (but Leap does not reliably) supports WASM memory up to full 4GiB (Leap's supported WASM limits 
-are only those as defined in the reference contracts which remain 33MiB). EOS-VM-OC was modified so that any growth beyond 33MiB
-is handled via `mprotect()`. This allows the optimization to remain in replace for all supported usages of Leap, while still allowing
-Leap to technically support the full Antelope protocol which allows any size up to 4GiB. However, this support still required 
-increasing the size of a slice to a full 8GiB of virtual memory, meaning that EOS VM OC now requires `529*8GiB` of virtual memory; about 4.2TiB.
-
-```mermaid
-flowchart TD
-   subgraph vm[Virtual Memory: 4.2TB]
-     direction LR
-     subgraph slice1[Slice 1 maps prologue]
-     end
-     subgraph slice2[Slice 2 maps prologue + 1 page]
-     end
-     subgraph slice529[Slice 529 maps prologue + 528 pages]
-     end
-   end
-   
-   subgraph lm[Linear Memory: 4GB]
-     direction TB
-     subgraph mapped[mapped memory: 33MB]
-     end
-     subgraph mprotected[mprotect memory: 4GB - 33MB]
-     end
-     mapped ~~~ mprotected
-   end
-   
-   slice1 ---> mapped
-   slice2 ---> mapped
-   slice529 ---> mapped
-```
-
-## Parallel WASM Execution
-
-### Parallel EOS-VM and EOS-VM-JIT Execution
-
-To support transaction execution on multiple threads, a separate `wasmif` is created for each thread.
-The runtime environments (compiled code and memory) are completely isolated from each other.
+To support read-only transaction execution on multiple threads, in the current implementation,
+a separate WASM interface is required for each thread.
+This ensures the backends (containing module and memory) of the same code running on different
+threads are completely isolated from each other.
 
 ```mermaid
 flowchart LR
-   subgraph wasmif_1
+  subgraph thread1[thread 1]
+   subgraph wasm1[wasmif]
       subgraph backend_1[backend]
          subgraph execution_ctx_1[execution context]
             direction TB
@@ -176,8 +209,9 @@ flowchart LR
          end
       end
    end
-
-   subgraph wasmif_2
+ end
+ subgraph thread2[thread 2]
+   subgraph wasmif2[wasmif]
       subgraph backend_2[backend]
          subgraph execution_ctx_2[execution context]
             direction TB
@@ -193,56 +227,199 @@ flowchart LR
          end
       end
    end
+ end
    
-   wasmif_1 ~~~ wasmif_2
+ thread1 ~~~ thread2
 
 ```
 
-### Parallel EOS-VM-OC Execution
-EOS-VM-OC was designed with multi-threaded support in mind. Only one `wasmif` is required. The same compiled code
-can be used on multiple threads; each thread uses its own executor and memory.
+#### Parallel EOS-VM-OC Execution
+EOS-VM-OC was designed with multi-threaded support in mind. Only one EOS-VM-OC tierup is required. 
+Multiple threads share the same compiled code, while each thread uses its own executor and memory.
 
 ```mermaid
-flowchart LR
+flowchart TD
    subgraph wasmif
-      subgraph eosvmoc[eosvmoc]
-         subgraph code[compiled code]
-            direction LR
-            subgraph runtime1[executor, memory]
-            end
-            subgraph runtime2[executor, memory]
-            end
-            
-            runtime1 ~~~ runtime2
+      subgraph eosvmoc[eosvmoc tierup]
+         subgraph code[OC compiled code]
          end
       end
    end
+   
+   subgraph thread1[thread 1]
+      direction TB
+      subgraph runtime11[executor]
+      end
+      subgraph runtime12[memory]
+      end
+      runtime11 ~~~ runtime12
+    end
+    
+      subgraph thread2[thread 2]
+      direction TB
+      subgraph runtime21[executor]
+      end
+      subgraph runtime22[memory]
+      end
+      runtime21 ~~~ runtime22
+    end
+
+    
+     wasmif --> thread1
+     wasmif --> thread2
 ```
 
-## Issues
+### Issues
+#### Same Contract Parsed Multiple Times in EOS-VM and EOS-VM-JIT
+In parallel EOS-VM and EOS-VM-JIT execution, each thread uses a separate WASM interface, which results in the same
+contract parsed multiple times. It is desirable to share the same parsed code -- module.
 
-### Same Contract Parsed Multiple Times in EOS-VM and EOS-VM-JIT
-In multi-threaded EOS-VM and EOS-VM-JIT execution, each thread requires a separate `wasmif`, which results in the same
-contract parsed multiple times. Reuse of the parsed code will improve performance.
+However, module stores global values (`current` in `global_variable`) directly.
+It is possible multiple threads modify the same global at the same time.
+This needs to be resolved before the same parsed code is shared among the same contract.
 
-### Large Virtual Memory Required in EOS-VM-OC
+The following illustrates how globals are used in the current implementation.
 
-EOS-VM-OC requires a separate memory for each executing thread. 
+```
+   struct global_variable {
+      global_type type;    // mutable or not
+      init_expr   init;    // initial value
+      init_expr   current; // current value
+   };
+```
+
+In EOS-VM, `current` is modified by `set_global` in `eos-vm/include/eosio/vm/execution_context.hpp`
+```
+      inline void set_global(uint32_t index, const operand_stack_elem& el) {
+      ...
+      auto& gl = _mod.globals[index];
+      ...
+      visit(overloaded{ [&](const i32_const_t& i) {
+         gl.current.value.i32 = i.data.ui;
+         },
+      ...
+```
+               
+In EOS-VM-JIT, `current` is directly modified in `eos-vm/include/eosio/vm/x86_64.hpp`
+```
+      void emit_set_global(uint32_t globalidx) {
+         ...
+         auto& gl = _mod.globals[globalidx];
+         void *ptr = &gl.current.value;
+         ...
+         emit_operand_ptr(ptr);
+         ...
+      }
+```
+
+All other sections in module are thread-safe. The following table summarizes the thread safety:
+
+| Section   | Description                                                                       | Thread Safe?|
+|-----------|-----------------------------------------------------------------------------------|-------------|
+| allocator | used only during parsing                                                          | yes         |
+| start     | index of start function, shareable                                                | yes         |
+| types     | type definitions, shareable                                                       | yes         |
+| imports   | imported functions, shareable                                                     | yes         |
+| functions | function definitions, shareable                                                   | yes         |
+| tables    | table definitions, shareable                                                      | yes         |
+| memories  | memory definition, shareable                                                      | yes         |
+| globals   | globals definitions and storage                                                   | no          |
+| exports   | exported functions, shareable                                                     | yes         |
+| elements  | used to initialize tables, shareable                                              | yes         |
+| code      | instructions, shareable                                                           | yes         |
+| data      | initial data, shareable                                                           | yes         |
+
+
+#### Large Virtual Memory Required in EOS-VM-OC
+
+The description of this section is mostly from https://github.com/AntelopeIO/leap/issues/645.
+
+EOS-VM-OC uses a memory mirroring technique so that WASM linear memory can be both protected via page access permissions
+and be resized without using `mprotect()`. EOS-VM-OC refers to these mirrors as "slices".
+
+Prior to 2.1/3.1, Antelope's WASM memory could never exceed 33MiB. EOS-VM-OC would set up `33MiB/64KiB+1=529` slices each
+with approximately `4GiB+33MiB` of virtual memory. This meant that EOS-VM-OC required approximately `529*(4GiB+33MiB)` of virtual memory;
+about 2.1TiB.
+
+In 2.1+/3.1+ Antelope technically (but Leap does not reliably) supports WASM memory up to full 4GiB (Leap's supported WASM limits 
+are only those as defined in the reference contracts which remain 33MiB). EOS-VM-OC was modified so that any growth beyond 33MiB
+is handled via `mprotect()`. This allows the optimization to remain in replace for all supported usages of Leap, while still allowing
+Leap to technically support the full Antelope protocol which allows any size up to 4GiB. However, this support still required 
+increasing the size of a slice to a full 8GiB of virtual memory, meaning that EOS VM OC now requires `529*8GiB` of virtual memory; about 4.2TiB.
+
+In EOS-VM-OC memory implementation, a prologue reserves the memory for fixed globals, table elements, and control block.
+Given a base virtual memory address and a WASM linear memory, 
+Slice 1 maps memory of prologue from the WASM linear memory starting address to base virtual memory address,
+Slice 2 maps memory of (prologue + 1 page) from the WASM linear memory starting address to (base virtual memory address + 8GB),
+...,
+Slice 529 maps memory of (prologue + 528 pages) from the WASM linear memory starting address to (base virtual memory address + 528 * 8GB)
+
+```mermaid
+flowchart TD
+   subgraph vm[Virtual Memory: 4.2TB]
+     direction LR
+     subgraph slice1[Slice 1 maps\n prologue]
+     end
+     subgraph slice2[Slice 2 maps\n prologue + 1 page]
+     end
+     ...
+     subgraph slice529[Slice 529 maps\n prologue + 528 pages]
+     end
+     subgraph largeMemory[request over\n prologue + 529 pages]
+     end
+   end
+   
+   subgraph lm[Linear Memory: 8GB]
+     direction TB
+     subgraph mapped[mapped memory: 33MB]
+     end
+     subgraph mprotected[mprotect memory: 8159MB]
+     end
+     mapped ~~~ mprotected
+   end
+   
+   slice1 ---> mapped
+   slice2 ---> mapped
+   slice529 ---> mapped
+   largeMemory ---> mprotected
+```
+
+As EOS-VM-OC requires a separate memory for each executing thread, this demands a large total virtual memory.
 For example, if 16 parallel threads are allowed with the current strategy of requiring 529 slices per thread, 
 that would require `16*4.2TiB` of virtual memory: more virtual memory than allowed on most processors. 
 Future efforts, like sync calls and background memory scrubbing, will also increase the need for more active slice sets.
 
-### Virtual Memory Available to User Space Not Calculated Accurately
+#### Virtual Memory Available to User Space Not Calculated Accurately
 
-To determine number of threads allowed for EOS-VM-OC, we need to know total virtual memory available to user space.
+To determine the number of threads allowed for EOS-VM-OC, we need to know total virtual memory available to user space.
 Currently we use `VmallocTotal` in `/prop/meminfo`. This is not accurate, as `VmallocTotal` reports virtual memory for kernel allocation;
 kernel itself uses some of it.
 
+#### Not Fallback to EOS-VM-Interpreter or EOS-VM-JIT When OC Compiled Code is Not Available
+In current parallel read-only transaction implementation, at `nodeos` startup, if EOS-VM-OC is enabled,
+only EOS-VM-OC is set up to support parallel execution, EOS-VM-Interpreter and EOS-VM-JIT are not set up to do so.
+This caused a problem that an execution cannot fall back to run parallelly if the OC compiled code is not available.
+A workaround was implemented to retry the execution in the future round. 
+This is not optimal, as it might take a while before the compile is done and the user will wait for
+non-deterministic time to get the transaction result.
+
 ## Proposed Solutions
 
-### Compile Once for the Same Contract in EOS-VM and EOS-VM-JIT
+### Compile the Same Contract Only Once in EOS-VM and EOS-VM-JIT
 
-To avoid parsing contract code multiple times, it is proposed the parsed module is shared by multiple execution contexts:
+To avoid parsing contract code multiple times, it is proposed the module is shared by multiple execution contexts.
+After a code is first parsed and a module is created, the module is cached, until removed from the cache when last block
+its code was used is before LIB and its linked execution context is not running. An new backend constructor
+takes a module as an input and skips parsing.
+
+To resolve the issue of potential multiple threads modifying the same global stored in the module,
+globals storage is moved out to the end of linear memory. Protection will be put into place to prevent this section is accessed
+by contract code.
+
+
+Functions `set_global` and `get_global` in `execution_context.hpp`, `emit_get_global` and `emit_set_global` in `x86_64.hpp` will
+be modified to access globals in linear memory.
+
 ```mermaid
 flowchart TD
    subgraph module[module]
@@ -288,75 +465,6 @@ flowchart TD
    
 ```
 
-However, module stores global values (`current` in `global_variable`) in the globals section. This makes globals not thread-safe.
-
-```
-   struct init_expr {
-      int8_t     opcode;
-      expr_value value;
-   };
-   struct global_type {
-      value_type content_type;
-      bool       mutability;
-   };
-   struct global_variable {
-      global_type type;
-      init_expr   init;
-      init_expr   current;
-   };
-```
-
-In EOS-VM, `current` is modified by `set_global` in `eos-vm/include/eosio/vm/execution_context.hpp`
-```
-      inline void set_global(uint32_t index, const operand_stack_elem& el) {
-      ...
-      auto& gl = _mod.globals[index];
-      ...
-      visit(overloaded{ [&](const i32_const_t& i) {
-         gl.current.value.i32 = i.data.ui;
-         },
-      ...
-```
-               
-In EOS-VM-JIT, `current` is directly accessed in `eos-vm/include/eosio/vm/x86_64.hpp`
-```
-      void emit_set_global(uint32_t globalidx) {
-         auto icount = fixed_size_instr(14);
-         auto& gl = _mod.globals[globalidx];
-         void *ptr = &gl.current.value;
-         // popq %rcx
-         emit_bytes(0x59);
-         // movabsq $ptr, %rax
-         emit_bytes(0x48, 0xb8);
-         emit_operand_ptr(ptr);
-         // movq %rcx, (%rax)
-         emit_bytes(0x48, 0x89, 0x08);
-      }
-```
-
-All other sections in module are thread-safe. The following table summarizes the thread safety:
-
-| Section   | Description                                                                       | Thread Safe?|
-|-----------|-----------------------------------------------------------------------------------|-------------|
-| allocator | used only during parsing                                                          | yes         |
-| start     | index of start function, shareable                                                | yes         |
-| types     | type definitions, shareable                                                       | yes         |
-| imports   | imported functions, shareable                                                     | yes         |
-| functions | function definitions, shareable                                                   | yes         |
-| tables    | table definitions, shareable                                                      | yes         |
-| memories  | memory definition, shareable                                                      | yes         |
-| globals   | globals definitions and storage                                                   | no          |
-| exports   | exported functions, shareable                                                     | yes         |
-| elements  | used to initialize tables, shareable                                              | yes         |
-| code      | instructions, shareable                                                           | yes         |
-| data      | initial data, shareable                                                           | yes         |
-
-We plan to
-- Move globals storage out from module and into linear memory
-- Modify `set_global` and `get_global` in `execution_context.hpp`, `emit_get_global` and `emit_set_global` in `x86_64.hpp`.
-- Cache parsed module per contract
-- Cached module is removed from the cache when last block its code was used is before LIB and its linked execution context is not running.
-
 ### Reduce Memory Slice Counts
 To conserve virtual memory to support more threads, We need to reduce the threshold where EOS VM OC transitions
 from mirroring to `mprotect()`.
@@ -368,7 +476,7 @@ We plan to
   * Replay the block logs.
   * Find max and 95 percentile of current_linear_memory_pages. This is to make sure vast majority of executions do not need using `mprotect`.
 - Add a private compile option defining the threshold number of pages where the transition between the two approaches occurs.
-  * In `chain/CMakefile`, set a Private variable `max_num_slices` and pass it to using `add_definitions` to C++ code.
+  * In `chain/CMakefile`, set a private variable `max_num_slices` with the value of the 95 percentile of current_linear_memory_pages, and pass it to using `add_definitions` to C++ code.
   * Use `max_num_slices` to set up memory slices in `memory::memory()`.
 
 ### Calculate Virtual Memory Available to User Space Accurately
@@ -387,3 +495,8 @@ A memory maps look like
 ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsyscall]
 ```
 
+### Fallback to EOS-VM-Interpreter or EOS-VM-JIT When OC Compiled Code is Not Available
+At `nodeos` startup, if EOS-VM-OC is enabled,
+EOS-VM-OC, EOS-VM-Interpreter, and EOS-VM-JIT all need to be set up to support parallel execution.
+In OC execution, if the OC compiled code is not available, the execution falls back to run parallelly in
+EOS-VM-Interpreter or EOS-VM-JIT. 

--- a/transactions/read-only/memory.md
+++ b/transactions/read-only/memory.md
@@ -1,0 +1,119 @@
+# Parallel Read-only Transaction Execution Improvements Proposal
+Several improvements were identified for parallel read-only transaction execution. This document describes problem statements and proposed solutions.
+
+## Compile Once for the Same Contract in EOS-VM and EOS-VM-JIT
+### Background
+https://github.com/AntelopeIO/leap/issues/800.
+
+Currently, in multi-threaded `EOS-VM` and `EOS-VM-JIT` execution, a `wasm_interface` object is created for each read-only thread. 
+If a contract is executed on multiple threads; the same contract is compiled multiple times by `wasm_interface` of the threads.
+
+The control flow on a single thread execution
+
+```mermaid
+flowchart TD
+    A[wasm_interface created at startup] -->|execute action| B[instantiated module cached?]
+    B -->|yes| F[return instantiated module]
+    B -->|no| C[compile contract]
+    C --> D[instantiate module]
+    D --> E[cache instantiated module]
+    E --> F
+    F --> G[execute action]
+```
+
+The excution contexts of multiple threads look like
+
+```mermaid
+flowchart LR
+    subgraph execution_ctx_1
+       direction TB
+       subgraph module1[module]
+         allocator
+         start
+         globals
+         others["..."]
+       end
+       module1 ~~~ LM[linear memory]
+       LM ~~~ WA[wasm allocator]
+    end
+
+    subgraph execution_ctx_2
+       direction TB
+       subgraph module2[module]
+         allocator2[allocator]
+         start2[start]
+         globals2[globals]
+         others2["..."]
+       end
+       module2 ~~~ LM2[linear memory]
+       LM2 ~~~ WA2[wasm allocator]
+    end
+
+    execution_ctx_1 ~~~ execution_ctx_2
+```
+
+In the current implementation of EOS-VM and EOS-VM-JIT, globals are part of module.
+### Proposed Solution
+Move globals out from module and into linear memory. `set_global` and `get_global` in execution_context.hpp need to be changed to point to the linear memory.
+TBD: Do we need to protect `set_global` when called from multi-threads?
+
+## Reduce EOS VM OC's memory slice count
+
+### Background
+https://github.com/AntelopeIO/leap/issues/645 
+
+This section mostly comes from the Github issue description with editorial changes.
+
+EOS VM OC uses a memory mirroring technique so that WASM linear memory can be both protected via page access permissions
+and be resized without usage of mprotect(). EOS VM OC refers to these mirrors as "slices".
+
+Prior to 2.1/3.1, Antelope's WASM memory could never exceed 33MiB. EOS VM OC would set up `33MiB/64KiB+1=529` slices each
+with approximately `4GiB+33MiB` of virtual memory. This meant that EOS VM OC required approximately `529*(4GiB+33MiB)` of virtual memory; about 2.1TiB.
+
+In 2.1+/3.1+ Antelope technically (but Leap does not reliably) supports WASM memory up to full 4GiB (Leap's supported WASM limits 
+are only those as defined in the reference contracts which remain 33MiB). EOS VM OC was modified so that any growth beyond 33MiB
+is handled via mprotect(). This allows the optimization to remain in replace for all supported usages of Leap, while still allowing
+Leap to technically support the full Antelope protocol which allows any size up to 4GiB. However, this support still required 
+increasing the size of a slice to a full 8GiB of virtual memory, meaning that EOS VM OC now requires `529*8GiB` of virtual memory; about 4.2TiB.
+
+Executing parallel read only transactions via EOS VM OC requires a set of slices for each executing thread. 
+If 16 parallel threads are allowed with the current strategy of requiring 529 slices per set, 
+that would require `16*4.2TiB` of virtual memory: more virtual memory than allowed on most processors. 
+Future efforts, like sync calls and background memory scrubbing, will also increase the need for more active slice sets.
+
+We need to reduce the threshold where EOS VM OC transitions from mirroring to mprotect() to conserve virtual memory. 
+
+### Proposed Solution
+- Gather memory usage from existing contracts. TBD. From mainnet? How?
+- Add a compile option (not "public" in cmake or such) defining the threshold number of pages where the transition between the two approaches occurs.
+
+## Calculate Virtual Memory Available to User Space
+
+### Background
+https://github.com/AntelopeIO/leap/issues/801
+
+After defining virtual memory required per thread, to determine number of threads allowed for EOS-VM-OC, we need to know
+total virtual memory available to user space.
+
+Currently we use `VmallocTotal` in `/prop/meminfo`. On a 5-level paging system, 
+`VmallocTotal` might report 64PB but mmap() will not give access to the extended range unless providing a hint which we currently don't do.
+In addition, `VmallocTotal` reports virtual memory for kernel allocation; kernel itself will use some of it.
+
+
+### Proposed Solution
+Approximately, we could use `/proc/self/maps`, find the difference of addresses between `nodeos` program text and `vsyscall` and deduct the total
+size of all memory segments.
+
+A memory maps look like
+```
+560e88dc8000-560e88dcc000 rw-p 04dee000 103:03 20582300                  /home/lh/work/leap-4-0-vmoc-main-thread/build/bin/nodeos
+560e88dcc000-560e88df7000 rw-p 00000000 00:00 0
+560e8a03d000-560e8a107000 rw-p 00000000 00:00 0                          [heap]
+...
+7ffdceec3000-7ffdceee4000 rw-p 00000000 00:00 0                          [stack]
+7ffdcefe2000-7ffdcefe6000 r--p 00000000 00:00 0                          [vvar]
+7ffdcefe6000-7ffdcefe8000 r-xp 00000000 00:00 0                          [vdso]
+ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsyscall]
+```
+
+

--- a/transactions/read-only/memory.md
+++ b/transactions/read-only/memory.md
@@ -1,107 +1,378 @@
-# Parallel Read-only Transaction Execution Improvements Proposal
-Several improvements were identified for parallel read-only transaction execution. This document describes problem statements and proposed solutions.
+# Parallel Read-only Transaction Execution Improvements
+Several improvement ideas related to WASM execution of parallel read-only trxs were identified: parsing contracts only once (https://github.com/AntelopeIO/leap/issues/800), reducing EOS-VM-OC memory slice count (https://github.com/AntelopeIO/leap/issues/645), and calculating virtual memory available to user space correctly (https://github.com/AntelopeIO/leap/issues/801).
 
-## Compile Once for the Same Contract in EOS-VM and EOS-VM-JIT
-### Background
-https://github.com/AntelopeIO/leap/issues/800.
+This document describes the background and solutions.
 
-Currently, in multi-threaded `EOS-VM` and `EOS-VM-JIT` execution, a `wasm_interface` object is created for each read-only thread. 
-If a contract is executed on multiple threads; the same contract is compiled multiple times by `wasm_interface` of the threads.
+## WASM Execution
+A transaction execution goes through two major phases:
+1. The smart contract of the transaction's actions are translated by CDT from C++ into WASM code.
+2. The WASM is executed by an EOS VM.
 
-The control flow on a single thread execution
+`nodeos` supports three types of VMs for WASM execution: EOS-VM (interpreter), EOS-VM-JIT, and EOS-VM-OC.
+
+At `nodeos` startup, resources required by WASM execution are created:
+- a WAMS interface `wasmif`
+- a `EOS-VM` or `EOS-VM-JIT` run time interface `eos_vm_runtime` (based on configuration option `--wasm-runtime`),
+- and a `eosvmoc_tier` (when `--eos-vm-oc-enable` is configured). `eosvmoc_tier` contains `eosvmoc::executor`
+and `eosvmoc::memory` used for execution. 
 
 ```mermaid
 flowchart TD
-    A[wasm_interface created at startup] -->|execute action| B[instantiated module cached?]
-    B -->|yes| F[return instantiated module]
-    B -->|no| C[compile contract]
-    C --> D[instantiate module]
-    D --> E[cache instantiated module]
-    E --> F
-    F --> G[execute action]
+    wasmif[create wasmif] --> runtime
+    runtime{EOS-VM or EOS-VM-JIT?} -->|JIT| jitVM
+    runtime -->|interpreter| intVM
+    jitVM[create JIT eos_vm_runtime] --> ocEnabled
+    intVM[create interpreter eos_vm_runtime] --> ocEnabled
+    ocEnabled{eos-vm-oc-enable?} -->|yes| ocTier
+    ocTier[create eosvmoc_tier]
 ```
 
-The excution contexts of multiple threads look like
+### EOS-VM and EOS-VM-JIT Execution
+
+EOS-VM and EOS-VM-JIT execute similarly. Both involves module, execution context, and backend.
+
+A module stores information about a parsed WASM code, consisting of WASM section definitions and generated bitcode or X86 machine code.
+```mermaid
+classDiagram
+   class module {
+      growable_allocator              allocator; 
+      uint32_t                        start; // index of start function
+      guarded_vector<func_type>       types; // type definitions
+      guarded_vector<import_entry>    imports; // imported functions
+      guarded_vector<uint32_t>        functions; // functions definitions
+      guarded_vector<table_type>      tables; // table definitions
+      guarded_vector<memory_type>     memories; // memory definitions
+      guarded_vector<global_variable> globals; // globals definitions and storage 
+      guarded_vector<export_entry>    exports; // export functions
+      guarded_vector<elem_segment>    elements; // element definitions
+      guarded_vector<function_body>   code; // generated code
+      guarded_vector<data_segment>    data; // initial data
+   }
+```
+
+An execution context provides a runtime environment to execute a function (action). It instantiates a module by linking the module with
+linear memory and stack, and initializing memory.
+```mermaid
+classDiagram
+   class execution_context_base {
+      char*                           _linear_memory;
+      module&                         _mod;
+      wasm_allocator*                 _wasm_alloc;
+      detail::host_invoker_t<Host>    _rhf;
+      operand_stack                   _os;
+   }
+   class jit_execution_context {
+      execute()
+      ...()
+   }
+   class execution_context {
+      execute()
+      ...()
+   }
+   execution_context_base <|-- jit_execution_context
+   execution_context_base <|-- execution_context
+```
+
+A backend encapsulates everything required for execution an action. The constructor of `backend` takes code,
+host functions, allocator and options as input, constructs a parser, parses the code, and creates the execution context as an output.
+
+Put together, given a contract WASM code and a function (action), `wasmif` executes the function in the following steps:
 
 ```mermaid
-flowchart LR
-    subgraph execution_ctx_1
-       direction TB
-       subgraph module1[module]
-         allocator
-         start
-         globals
-         others["..."]
-       end
-       module1 ~~~ LM[linear memory]
-       LM ~~~ WA[wasm allocator]
-    end
-
-    subgraph execution_ctx_2
-       direction TB
-       subgraph module2[module]
-         allocator2[allocator]
-         start2[start]
-         globals2[globals]
-         others2["..."]
-       end
-       module2 ~~~ LM2[linear memory]
-       LM2 ~~~ WA2[wasm allocator]
-    end
-
-    execution_ctx_1 ~~~ execution_ctx_2
+flowchart TD
+    isBackendCached{backend for the code cached?} -->|No| backend
+    isBackendCached -->|Yes| exec
+    backend[create a backend] --> module
+    module[create a module] --> isjit
+    isjit{JIT?} -->|JIT| jitParse
+    isjit -->|interpreter| intParse
+    jitParse[parse the contract code, populate module, generate X86 machine code] --> jitCtx
+    intParse[parse the contract code, populate module, generate bitcode] --> intCtx
+    jitCtx[create a JIT execution context] --> exec
+    intCtx[create an interpreter execution context] --> exec
+    exec[execute the function]
 ```
 
-In the current implementation of EOS-VM and EOS-VM-JIT, globals are part of module.
-### Proposed Solution
-Move globals out from module and into linear memory. `set_global` and `get_global` in execution_context.hpp need to be changed to point to the linear memory.
-TBD: Do we need to protect `set_global` when called from multi-threads?
+### EOS-VM-OC Execution
+To improve the performance, EOS-VM-OC compiles and generates optimized code.
 
-## Reduce EOS VM OC's memory slice count
+Given a contract WASM code and a function, `eosvmoc_tier` executes the function in the following steps:
 
-### Background
-https://github.com/AntelopeIO/leap/issues/645 
+```mermaid
+flowchart TD
+    cached{code compiled and cached?} -->|yes| exec
+    cached -->|no| default
+    exec[executor::execute] --> mem
+    mem[prepare memory] --> cb
+    cb[prepare control block] --> setApply
+    setApply[set up apply func] --> apply
+    apply["call apply func"]
+    default[fall back to base runtime for execution]
+```
+#### Memory Slices
 
-This section mostly comes from the Github issue description with editorial changes.
+The description of this section is from https://github.com/AntelopeIO/leap/issues/645.
 
-EOS VM OC uses a memory mirroring technique so that WASM linear memory can be both protected via page access permissions
-and be resized without usage of mprotect(). EOS VM OC refers to these mirrors as "slices".
+EOS-VM-OC uses a memory mirroring technique so that WASM linear memory can be both protected via page access permissions
+and be resized without using `mprotect()`. EOS VM OC refers to these mirrors as "slices".
 
-Prior to 2.1/3.1, Antelope's WASM memory could never exceed 33MiB. EOS VM OC would set up `33MiB/64KiB+1=529` slices each
-with approximately `4GiB+33MiB` of virtual memory. This meant that EOS VM OC required approximately `529*(4GiB+33MiB)` of virtual memory; about 2.1TiB.
+Prior to 2.1/3.1, Antelope's WASM memory could never exceed 33MiB. EOS-VM-OC would set up `33MiB/64KiB+1=529` slices each
+with approximately `4GiB+33MiB` of virtual memory. This meant that EOS-VM-OC required approximately `529*(4GiB+33MiB)` of virtual memory;
+about 2.1TiB.
 
 In 2.1+/3.1+ Antelope technically (but Leap does not reliably) supports WASM memory up to full 4GiB (Leap's supported WASM limits 
-are only those as defined in the reference contracts which remain 33MiB). EOS VM OC was modified so that any growth beyond 33MiB
-is handled via mprotect(). This allows the optimization to remain in replace for all supported usages of Leap, while still allowing
+are only those as defined in the reference contracts which remain 33MiB). EOS-VM-OC was modified so that any growth beyond 33MiB
+is handled via `mprotect()`. This allows the optimization to remain in replace for all supported usages of Leap, while still allowing
 Leap to technically support the full Antelope protocol which allows any size up to 4GiB. However, this support still required 
 increasing the size of a slice to a full 8GiB of virtual memory, meaning that EOS VM OC now requires `529*8GiB` of virtual memory; about 4.2TiB.
 
-Executing parallel read only transactions via EOS VM OC requires a set of slices for each executing thread. 
-If 16 parallel threads are allowed with the current strategy of requiring 529 slices per set, 
+```mermaid
+flowchart TD
+   subgraph vm[Virtual Memory: 4.2TB]
+     direction LR
+     subgraph slice1[Slice 1 maps prologue]
+     end
+     subgraph slice2[Slice 2 maps prologue + 1 page]
+     end
+     subgraph slice529[Slice 529 maps prologue + 528 pages]
+     end
+   end
+   
+   subgraph lm[Linear Memory: 4GB]
+     direction TB
+     subgraph mapped[mapped memory: 33MB]
+     end
+     subgraph mprotected[mprotect memory: 4GB - 33MB]
+     end
+     mapped ~~~ mprotected
+   end
+   
+   slice1 ---> mapped
+   slice2 ---> mapped
+   slice529 ---> mapped
+```
+
+## Parallel WASM Execution
+
+### Parallel EOS-VM and EOS-VM-JIT Execution
+
+To support transaction execution on multiple threads, a separate `wasmif` is created for each thread.
+The runtime environments (compiled code and memory) are completely isolated from each other.
+
+```mermaid
+flowchart LR
+   subgraph wasmif_1
+      subgraph backend_1[backend]
+         subgraph execution_ctx_1[execution context]
+            direction TB
+            subgraph module1[module]
+            end
+            subgraph LM1[linear memory]
+            end
+            subgraph Stack1[stack]
+            end
+            module1 ~~~ LM1
+            LM1 ~~~ Stack1
+         end
+      end
+   end
+
+   subgraph wasmif_2
+      subgraph backend_2[backend]
+         subgraph execution_ctx_2[execution context]
+            direction TB
+            subgraph module2[module]
+            end
+            subgraph LM2[linear memory]
+            end
+            subgraph Stack2[stack]
+            end
+            module2 ~~~ LM2
+            LM2 ~~~ Stack2
+
+         end
+      end
+   end
+   
+   wasmif_1 ~~~ wasmif_2
+
+```
+
+### Parallel EOS-VM-OC Execution
+EOS-VM-OC was designed with multi-threaded support in mind. Only one `wasmif` is required. The same compiled code
+can be used on multiple threads; each thread uses its own executor and memory.
+
+```mermaid
+flowchart LR
+   subgraph wasmif
+      subgraph eosvmoc[eosvmoc]
+         subgraph code[compiled code]
+            direction LR
+            subgraph runtime1[executor, memory]
+            end
+            subgraph runtime2[executor, memory]
+            end
+            
+            runtime1 ~~~ runtime2
+         end
+      end
+   end
+```
+
+## Issues
+
+### Same Contract Parsed Multiple Times in EOS-VM and EOS-VM-JIT
+In multi-threaded EOS-VM and EOS-VM-JIT execution, each thread requires a separate `wasmif`, which results in the same
+contract parsed multiple times. Reuse of the parsed code will improve performance.
+
+### Large Virtual Memory Required in EOS-VM-OC
+
+EOS-VM-OC requires a separate memory for each executing thread. 
+For example, if 16 parallel threads are allowed with the current strategy of requiring 529 slices per thread, 
 that would require `16*4.2TiB` of virtual memory: more virtual memory than allowed on most processors. 
 Future efforts, like sync calls and background memory scrubbing, will also increase the need for more active slice sets.
 
-We need to reduce the threshold where EOS VM OC transitions from mirroring to mprotect() to conserve virtual memory. 
+### Virtual Memory Available to User Space Not Calculated Accurately
 
-### Proposed Solution
-- Gather memory usage from existing contracts. TBD. From mainnet? How?
-- Add a compile option (not "public" in cmake or such) defining the threshold number of pages where the transition between the two approaches occurs.
+To determine number of threads allowed for EOS-VM-OC, we need to know total virtual memory available to user space.
+Currently we use `VmallocTotal` in `/prop/meminfo`. This is not accurate, as `VmallocTotal` reports virtual memory for kernel allocation;
+kernel itself uses some of it.
 
-## Calculate Virtual Memory Available to User Space
+## Proposed Solutions
 
-### Background
-https://github.com/AntelopeIO/leap/issues/801
+### Compile Once for the Same Contract in EOS-VM and EOS-VM-JIT
 
-After defining virtual memory required per thread, to determine number of threads allowed for EOS-VM-OC, we need to know
-total virtual memory available to user space.
+To avoid parsing contract code multiple times, it is proposed the parsed module is shared by multiple execution contexts:
+```mermaid
+flowchart TD
+   subgraph module[module]
+   end
+%%  subgraph wamsifs
+%%  direction LR
+   subgraph wasmif_1
+      subgraph backend_1[backend]
+         subgraph execution_ctx_1[execution context]
+            direction TB
+  %%          subgraph module1[module]
+  %%          end
+            subgraph LM1[linear memory]
+            end
+            subgraph Stack1[stack]
+            end
+   %%         module1 ~~~ LM1
+            LM1 ~~~ Stack1
+         end
+      end
+   end
 
-Currently we use `VmallocTotal` in `/prop/meminfo`. On a 5-level paging system, 
-`VmallocTotal` might report 64PB but mmap() will not give access to the extended range unless providing a hint which we currently don't do.
-In addition, `VmallocTotal` reports virtual memory for kernel allocation; kernel itself will use some of it.
+   subgraph wasmif_2
+      subgraph backend_2[backend]
+         subgraph execution_ctx_2[execution context]
+            direction TB
+     %%       subgraph module2[module]
+     %%      end
+            subgraph LM2[linear memory]
+            end
+            subgraph Stack2[stack]
+            end
+     %%     module2 ~~~ LM2
+            LM2 ~~~ Stack2
+         end
+      end
+   end   
+   wasmif_1 ~~~ wasmif_2
+%%   end
+%%   module1 --- module2
+   module --> wasmif_1
+   module --> wasmif_2
+   
+```
 
+However, module stores global values (`current` in `global_variable`) in the globals section. This makes globals not thread-safe.
 
-### Proposed Solution
-Approximately, we could use `/proc/self/maps`, find the difference of addresses between `nodeos` program text and `vsyscall` and deduct the total
+```
+   struct init_expr {
+      int8_t     opcode;
+      expr_value value;
+   };
+   struct global_type {
+      value_type content_type;
+      bool       mutability;
+   };
+   struct global_variable {
+      global_type type;
+      init_expr   init;
+      init_expr   current;
+   };
+```
+
+In EOS-VM, `current` is modified by `set_global` in `eos-vm/include/eosio/vm/execution_context.hpp`
+```
+      inline void set_global(uint32_t index, const operand_stack_elem& el) {
+      ...
+      auto& gl = _mod.globals[index];
+      ...
+      visit(overloaded{ [&](const i32_const_t& i) {
+         gl.current.value.i32 = i.data.ui;
+         },
+      ...
+```
+               
+In EOS-VM-JIT, `current` is directly accessed in `eos-vm/include/eosio/vm/x86_64.hpp`
+```
+      void emit_set_global(uint32_t globalidx) {
+         auto icount = fixed_size_instr(14);
+         auto& gl = _mod.globals[globalidx];
+         void *ptr = &gl.current.value;
+         // popq %rcx
+         emit_bytes(0x59);
+         // movabsq $ptr, %rax
+         emit_bytes(0x48, 0xb8);
+         emit_operand_ptr(ptr);
+         // movq %rcx, (%rax)
+         emit_bytes(0x48, 0x89, 0x08);
+      }
+```
+
+All other sections in module are thread-safe. The following table summarizes the thread safety:
+
+| Section   | Description                                                                       | Thread Safe?|
+|-----------|-----------------------------------------------------------------------------------|-------------|
+| allocator | used only during parsing                                                          | yes         |
+| start     | index of start function, shareable                                                | yes         |
+| types     | type definitions, shareable                                                       | yes         |
+| imports   | imported functions, shareable                                                     | yes         |
+| functions | function definitions, shareable                                                   | yes         |
+| tables    | table definitions, shareable                                                      | yes         |
+| memories  | memory definition, shareable                                                      | yes         |
+| globals   | globals definitions and storage                                                   | no          |
+| exports   | exported functions, shareable                                                     | yes         |
+| elements  | used to initialize tables, shareable                                              | yes         |
+| code      | instructions, shareable                                                           | yes         |
+| data      | initial data, shareable                                                           | yes         |
+
+We plan to
+- Move globals storage out from module and into linear memory
+- Modify `set_global` and `get_global` in `execution_context.hpp`, `emit_get_global` and `emit_set_global` in `x86_64.hpp`.
+- Cache parsed module per contract
+- Cached module is removed from the cache when last block its code was used is before LIB and its linked execution context is not running.
+
+### Reduce Memory Slice Counts
+To conserve virtual memory to support more threads, We need to reduce the threshold where EOS VM OC transitions
+from mirroring to `mprotect()`.
+
+We plan to
+- Gather memory usage from existing contracts.
+  * Select most recent one year's EOS Mainnet snapshots and block logs.
+  * Modify `eosvmoc::executor::execute()` to report `cb->current_linear_memory_pages` at the end of execution.
+  * Replay the block logs.
+  * Find max and 95 percentile of current_linear_memory_pages. This is to make sure vast majority of executions do not need using `mprotect`.
+- Add a private compile option defining the threshold number of pages where the transition between the two approaches occurs.
+  * In `chain/CMakefile`, set a Private variable `max_num_slices` and pass it to using `add_definitions` to C++ code.
+  * Use `max_num_slices` to set up memory slices in `memory::memory()`.
+
+### Calculate Virtual Memory Available to User Space Accurately
+We plan to use `/proc/self/maps`, find the difference of addresses between `nodeos` program text and `vsyscall` and deduct the total
 size of all memory segments.
 
 A memory maps look like
@@ -115,5 +386,4 @@ A memory maps look like
 7ffdcefe6000-7ffdcefe8000 r-xp 00000000 00:00 0                          [vdso]
 ffffffffff600000-ffffffffff601000 --xp 00000000 00:00 0                  [vsyscall]
 ```
-
 

--- a/transactions/read-only/memory.md
+++ b/transactions/read-only/memory.md
@@ -471,9 +471,9 @@ from mirroring to `mprotect()`.
 
 We plan to
 - Gather memory usage from existing contracts.
-  * Select most recent one year's EOS Mainnet snapshots and block logs.
-  * Modify `eosvmoc::executor::execute()` to report `cb->current_linear_memory_pages` at the end of execution.
-  * Replay the block logs.
+  * Download a snapshot of the beginning of 2022 from mainnet.
+  * Modify `libraries/chain/webassembly/runtimes/eos-vm-oc/gs_seg_helpers.c/eos_vm_oc_grow_memory()` to keep track the largest `current_linear_memory_page` the current code uses, and modify `eosvmoc::executor::execute()` to report `current_linear_memory_pages` at the end of the action execution.
+  * Start from the snapshot and sync with a mainnet peer node.
   * Find max and 95 percentile of current_linear_memory_pages. This is to make sure vast majority of executions do not need using `mprotect`.
 - Add a private compile option defining the threshold number of pages where the transition between the two approaches occurs.
   * In `chain/CMakefile`, set a private variable `max_num_slices` with the value of the 95 percentile of current_linear_memory_pages, and pass it to using `add_definitions` to C++ code.


### PR DESCRIPTION
During parallel read-only transaction implementation (https://github.com/eosnetworkfoundation/product/blob/main/transactions/read-only/parallel.md, https://github.com/AntelopeIO/leap/pull/776), several improvement ideas related to WASM execution were identified: parsing contracts only once (https://github.com/AntelopeIO/leap/issues/800), reducing EOS-VM-OC memory slice count (https://github.com/AntelopeIO/leap/issues/645), calculating virtual memory available to user space accurately (https://github.com/AntelopeIO/leap/issues/801), and falling back to parallel EOS-VM-Interpreter or EOS-VM-JIT execution if OC compiled code is not available (https://github.com/AntelopeIO/leap/issues/1119).

This document describes the background and proposes approaches to the issues.